### PR TITLE
fix: useEffectが二重実行されて意図してないユーザーが作成されることを防ぐようにする

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,10 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { onAuthStateChanged, signInAnonymously, User } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  // ログイン中かどうかを管理するためのref
+  // Strict Modeでの二重実行対策
+  const isLoggingIn = useRef(false);
 
   useEffect(() => {
     // ログイン状態を監視
@@ -12,11 +15,14 @@ export function useAuth() {
       if (currentUser) {
         setUser(currentUser);
         setLoading(false);
-      } else {
+        isLoggingIn.current = false;
+      } else if (!isLoggingIn.current) {
+        isLoggingIn.current = true;
         // 未ログインなら、ここで自動的に匿名ログインさせる
         signInAnonymously(auth).catch((error) => {
           console.error("Login Failed:", error);
           setLoading(false);
+          isLoggingIn.current = false;
         });
       }
     });


### PR DESCRIPTION
#10 
useAuth.tsにてuseEffectが二重実行されるために匿名ユーザーが意図せず2名作成されてしまっていた。

これはReactのStrict Modeの挙動によるものであり、本番環境では発生しないはずではある。

開発中に2名のユーザーが作られるのも困るのでログイン中かどうかのフラグをおいて確認するようにする