### PR TITLE
change: 平均値の表示を四捨五入した整数に変更

### DIFF
--- a/src/app/rooms/[id]/_components/Board.tsx
+++ b/src/app/rooms/[id]/_components/Board.tsx
@@ -31,7 +31,7 @@ export function Board({ roomId }: Props) {
     .filter((vote) => typeof vote === 'number') as number[];
   const average =
     validVotes.length > 0
-      ? (validVotes.reduce((sum, vote) => sum + vote, 0) / validVotes.length).toFixed(1)
+      ? Math.round(validVotes.reduce((sum, vote) => sum + vote, 0) / validVotes.length)
       : null;
 
   const handleRemovePlayer = (targetUid: string) => {


### PR DESCRIPTION
## Summary
- 平均値の表示を `toFixed(1)`（小数第一位までの文字列）から `Math.round(...)`（四捨五入した整数）に変更

## Test plan
- [ ] ルーム内で複数人が投票し、open した時に平均値が整数で表示されることを確認
- [ ] 端数が出るケース（例: 1, 2, 3）でも整数で四捨五入されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)