### PR TITLE
add: 次のゲームへ移行時に前回ラウンドの平均を表示

### DIFF
--- a/src/app/rooms/[id]/_components/Board.tsx
+++ b/src/app/rooms/[id]/_components/Board.tsx
@@ -44,6 +44,7 @@ export function Board({ roomId }: Props) {
     if (!roomId || !roomData?.users) return;
     const updates: Record<string, unknown> = {
       [`rooms/${roomId}/status`]: 'voting',
+      [`rooms/${roomId}/previousAverage`]: average,
       ...Object.keys(roomData.users).reduce<Record<string, null>>((acc, uid) => {
         acc[`rooms/${roomId}/users/${uid}/vote`] = null;
         return acc;
@@ -110,6 +111,11 @@ export function Board({ roomId }: Props) {
               {participatingUsers.filter(([, u]) => u.vote !== null && u.vote !== undefined).length} /{' '}
               {participatingUsers.length} 人が投票済み
             </p>
+            {typeof roomData?.previousAverage === 'number' && (
+              <p className="text-[11px] sm:text-sm text-gray-400">
+                前回の平均: <span className="font-bold text-gray-500">{roomData.previousAverage}</span>
+              </p>
+            )}
             <div className="flex justify-center gap-2 sm:gap-3 pt-1.5 sm:pt-2">
               <button
                 onClick={handleRevealResults}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,4 +11,5 @@ export interface Room {
   status: 'voting' | 'revealed'; // 投票中 または 開示済み
   users: Record<string, User>;   // IDをキーにしたUserオブジェクト
   createdAt: number;
+  previousAverage?: number | null; // 直前ラウンドの平均（未実施時は undefined）
 }


### PR DESCRIPTION
## 概要

ユーザーが誤って（あるいは意図的に）「次のゲームへ」を押した後、直前ラウンドの結果がわからなくなってしまう問題を解消します。

`次のゲームへ`移行時に現在の平均値をルームに保存し、次の投票画面で「前回の平均」として表示するようにしました。

## 変更内容

- `src/types.ts`: `Room` に `previousAverage?: number | null` を追加
- `src/app/rooms/[id]/_components/Board.tsx`:
  - `handleNextGame` でリセット直前の平均値を `previousAverage` として保存
  - 投票中の画面に「前回の平均」を表示（初回や前回有効投票なしの場合は非表示）

## 設計上の注意

- 表示条件を `typeof === 'number'` にすることで `null`（前回有効投票なし）/`undefined`（初回）の両方を非表示にできる
- 既存ルーム（`previousAverage` 未保持のドキュメント）も後方互換で安全に動作する

## 動作確認

- `npm run build`（TypeScript型チェック含む）が成功することを確認
- 投票 → 結果開示 → 次のゲームへ で前回平均が表示されることを想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)